### PR TITLE
corrected data() method to attr() and "category" to "data-category"

### DIFF
--- a/class-01-jquery-and-the-dom/pair-assignment/starter-code/scripts/article.js
+++ b/class-01-jquery-and-the-dom/pair-assignment/starter-code/scripts/article.js
@@ -9,7 +9,7 @@ function Article (opts) {
 Article.prototype.toHtml = function() {
   var $newArticle = $('article.template').clone();
 
-  $newArticle.data('category', this.category);
+  $newArticle.attr('data-category', this.category);
 
   // TODO: Use jQuery to fill in the template with properties
   // from this particular Article instance. We need to fill in:


### PR DESCRIPTION
The data() method was confusing to a lot of students. I believe the attr() method should be used here to change the "data-category" attribute of the article tag.
